### PR TITLE
[追加] ワールド情報登録タブと設定タブのユニットテストを追加

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,13 @@ export default defineConfig([{
     }],
     'no-restricted-imports': ['error', { 'patterns': ['../']}],
   },
+
+  overrides: [{
+    'files': ['*.test.ts', '*.test.tsx'],
+    'rules': {
+      '@typescript-eslint/no-explicit-any': 'off'
+    }
+  }]
 }, globalIgnores([
   '.webpack/**',
 ])]);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,13 +58,11 @@ export default defineConfig([{
     }],
     'no-restricted-imports': ['error', { 'patterns': ['../']}],
   },
-
-  overrides: [{
-    'files': ['*.test.ts', '*.test.tsx'],
-    'rules': {
-      '@typescript-eslint/no-explicit-any': 'off'
-    }
-  }]
+}, {
+  files: ['**/*.test.ts', '**/*.test.tsx'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
 }, globalIgnores([
   '.webpack/**',
 ])]);

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,5 +13,6 @@ module.exports = {
     '\\.(css|scss)$': 'identity-obj-proxy',
     '\\.svg$': '<rootDir>/__mocks__/svgMock.js',
     '^src/(.*)$': '<rootDir>/src/$1',
+    '^commonComponents/(.*)$': '<rootDir>/src/react-components/common/$1',
   },
 };

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -9,3 +9,16 @@ global.AnimationEvent = class AnimationEvent extends Event {
     this.pseudoElement = eventInitDict?.pseudoElement || '';
   }
 };
+
+beforeAll(() => {
+  global.window.dbAPI = {
+    updateWorldBookmark: jest.fn().mockResolvedValue(undefined),
+    updateWorldGenres: jest.fn().mockResolvedValue(undefined),
+    getGenres: jest.fn().mockResolvedValue([]),
+    getVisitStatuses: jest.fn().mockResolvedValue([]),
+    addOrUpdateWorldInfo: jest.fn().mockResolvedValue({}),
+    getWorldInfo: jest.fn().mockResolvedValue({}),
+    getBookmarkList: jest.fn().mockResolvedValue({bookmarkList: [], totalCount: 1}),
+    getWorldIdsToUpdate: jest.fn().mockResolvedValue([]),
+  };
+});

--- a/src/react-components/common/world-card.test.tsx
+++ b/src/react-components/common/world-card.test.tsx
@@ -58,19 +58,6 @@ const worldInfo: VRChatWorldInfo = {
   visitStatusId: 2,
 };
 
-beforeAll(() => {
-  global.window.dbAPI = {
-    updateWorldBookmark: jest.fn().mockResolvedValue(undefined),
-    updateWorldGenres: jest.fn().mockResolvedValue(undefined),
-    getGenres: jest.fn().mockResolvedValue([]),
-    getVisitStatuses: jest.fn().mockResolvedValue([]),
-    addOrUpdateWorldInfo: jest.fn().mockResolvedValue({}),
-    getWorldInfo: jest.fn().mockResolvedValue({}),
-    getBookmarkList: jest.fn().mockResolvedValue({bookmarkList: [worldInfo], totalCount: 1}),
-    getWorldIdsToUpdate: jest.fn().mockResolvedValue([]),
-  };
-});
-
 describe('WorldCard', () => {
   it('ワールド名・作者・説明などが表示される', () => {
     render(<WorldCard worldInfo={worldInfo} />);

--- a/src/react-components/data-entry/world-data-entry.test.tsx
+++ b/src/react-components/data-entry/world-data-entry.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { WorldDataEntry } from './world-data-entry';
+
+import '@testing-library/jest-dom';
+import { useWorldDataEntryState } from 'src/contexts/world-data-entry-provider';
+
+const WORLD_ID = 'wrld_15fe33f1-937e-4e93-8a40-902fb9552a11';
+const WORLD_NAME = 'VerySimpleWorld';
+
+jest.mock('commonComponents/button', () => ({
+  Button: (props: any) => <button {...props}>{props.children}</button>,
+}));
+jest.mock('commonComponents/input-text', () => ({
+  InputText: (props: any) => (
+    <input
+      value={props.value}
+      onChange={props.onChange}
+      onKeyDown={props.onKeyDown}
+      onBlur={props.onBlur}
+      placeholder={props.placeholder}
+      className={props.className}
+    />
+  ),
+}));
+jest.mock('commonComponents/world-card', () => ({
+  WorldCard: (props: any) => <div data-testid="mock-world-card">{JSON.stringify(props.worldInfo)}</div>,
+}));
+
+const addToast = jest.fn();
+jest.mock('src/contexts/toast-provider', () => ({
+  useToast: () => ({
+    addToast,
+  }),
+}));
+jest.mock('src/contexts/world-data-entry-provider', () => {
+  const state = {
+    worldIdOrUrl: '',
+    setWorldIdOrUrl: jest.fn(),
+    vrchatWorldInfo: {},
+    setVRChatWorldInfo: jest.fn(),
+  };
+  return {
+    useWorldDataEntryState: () => state,
+  };
+});
+jest.mock('src/utils/util', () => ({
+  debounce: (fn: any) => fn,
+  getWorldId: (value: string) => {
+    if (value === WORLD_ID) return value;
+    if (value === `https://vrchat.com/home/world/${WORLD_ID}/info`) return WORLD_ID;
+    return null;
+  },
+}));
+
+describe('WorldDataEntry', () => {
+  beforeEach(() => {
+    const state = useWorldDataEntryState();
+    Object.assign(state, {
+      worldIdOrUrl: '',
+      setWorldIdOrUrl: jest.fn(),
+      vrchatWorldInfo: {id: 'wrld_15fe33f1-937e-4e93-8a40-902fb9552a11', name: 'VerySimpleWorld'},
+      setVRChatWorldInfo: jest.fn(),
+    });
+    jest.clearAllMocks();
+  });
+
+  it('入力欄とボタンが表示される', () => {
+    render(<WorldDataEntry />);
+    expect(screen.getByPlaceholderText('World ID or World URL')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeInTheDocument();
+  });
+
+  it('無効なID入力時にエラーメッセージが表示される', () => {
+    const state = useWorldDataEntryState();
+    state.worldIdOrUrl = 'invalid';
+    render(<WorldDataEntry />);
+    expect(screen.getByText(/無効なワールドIDまたはURL/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeDisabled();
+  });
+
+  it('有効なID入力時はボタンが有効', () => {
+    const state = useWorldDataEntryState();
+    state.worldIdOrUrl = WORLD_ID;
+    render(<WorldDataEntry />);
+    expect(screen.queryByText(/無効なワールドIDまたはURL/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeEnabled();
+  });
+
+  it('ボタン押下でAPIが呼ばれ、成功時にトーストとsetVRChatWorldInfoが呼ばれる', async () => {
+    // const setVRChatWorldInfo = jest.fn();
+    const state = useWorldDataEntryState();
+    state.worldIdOrUrl = WORLD_ID;
+    window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockResolvedValue({ data: { id: WORLD_ID, name: WORLD_NAME } });
+
+    render(<WorldDataEntry />);
+    fireEvent.click(screen.getByRole('button', { name: 'ワールド情報登録' }));
+
+    await waitFor(() => {
+      expect(window.dbAPI.addOrUpdateWorldInfo).toHaveBeenCalledWith(WORLD_ID);
+      expect(addToast).toHaveBeenCalledWith('ワールド情報を取得しました。', expect.anything());
+      expect(state.setVRChatWorldInfo).toHaveBeenCalledWith({ id: WORLD_ID, name: WORLD_NAME });
+    });
+  });
+
+  it('APIエラー時はエラートーストが表示される', async () => {
+    const state = useWorldDataEntryState();
+    state.worldIdOrUrl = WORLD_ID;
+
+    window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockResolvedValue({ error: 'APIエラー', data: null });
+
+    render(<WorldDataEntry />);
+    fireEvent.click(screen.getByRole('button', { name: 'ワールド情報登録' }));
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(
+        expect.stringContaining('ワールド情報の取得に失敗しました。エラー: APIエラー'),
+        expect.anything(),
+      );
+    });
+  });
+
+  it('APIがデータもエラーも返さない場合は予期せぬエラーのトースト', async () => {
+    const state = useWorldDataEntryState();
+    state.worldIdOrUrl = WORLD_ID;
+    window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockResolvedValue({});
+
+    render(<WorldDataEntry />);
+    fireEvent.click(screen.getByRole('button', { name: 'ワールド情報登録' }));
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(
+        expect.stringContaining('予期せぬエラーが発生しました。'),
+        expect.anything(),
+      );
+    });
+  });
+
+  it('WorldCardが表示される', () => {
+    const state = useWorldDataEntryState();
+    state.worldIdOrUrl = WORLD_ID;
+
+    render(<WorldDataEntry />);
+    expect(screen.getByTestId('mock-world-card')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-world-card').textContent).toContain(WORLD_NAME);
+  });
+});

--- a/src/react-components/settings/settings.test.tsx
+++ b/src/react-components/settings/settings.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { Settings } from './settings';
+
+jest.mock('./world-update-progress', () => ({
+  WorldUpdateProgress: () => <div data-testid="mock-world-update-progress">Mock WorldUpdateProgress</div>,
+}));
+
+describe('Settings', () => {
+  it('設定画面が正しくレンダリングされる', () => {
+    render(<Settings />);
+
+    // タイトルが表示されることを確認
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('設定');
+
+    // ワールドデータ更新セクションが表示されることを確認
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('ワールドデータ更新');
+    expect(screen.getByText(/24時間以上前に取得したワールドデータを対象に最新情報へ更新します。/)).toBeInTheDocument();
+
+    // WorldUpdateProgressコンポーネントが正しくレンダリングされることを確認
+    expect(screen.getByTestId('mock-world-update-progress')).toBeInTheDocument();
+  });
+});

--- a/src/react-components/settings/world-update-progress.test.tsx
+++ b/src/react-components/settings/world-update-progress.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {act} from 'react';
+
+import { WorldUpdateProgress } from './world-update-progress';
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+jest.mock('src/consts/const', () => ({
+  WORLD_UPDATE_INFO_STATUS: {
+    idle: 'idle',
+    updating: 'updating',
+    noTarget: 'noTarget',
+    error: 'error',
+    completed: 'completed',
+  },
+}));
+
+jest.mock('src/react-components/common/button', () => ({
+  Button: (props: any) => <button {...props}>{props.children}</button>,
+}));
+
+const mockSetUpdateTargetTotal = jest.fn();
+const mockSetProcessedCount = jest.fn();
+const mockSetWorldInfoIsUpdating = jest.fn();
+const mockSetWorldInfoUpdateStatus = jest.fn();
+
+let state = {
+  updateTargetTotal: 0,
+  setUpdateTargetTotal: mockSetUpdateTargetTotal,
+  processedCount: 0,
+  setProcessedCount: mockSetProcessedCount,
+  worldInfoIsUpdating: false,
+  setWorldInfoIsUpdating: mockSetWorldInfoIsUpdating,
+  worldInfoUpdateStatus: 'idle',
+  setWorldInfoUpdateStatus: mockSetWorldInfoUpdateStatus,
+};
+
+jest.mock('src/contexts/settings-tab-provider', () => ({
+  useSettingsTabState: () => state,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  state = {
+    updateTargetTotal: 0,
+    setUpdateTargetTotal: mockSetUpdateTargetTotal,
+    processedCount: 0,
+    setProcessedCount: mockSetProcessedCount,
+    worldInfoIsUpdating: false,
+    setWorldInfoIsUpdating: mockSetWorldInfoIsUpdating,
+    worldInfoUpdateStatus: 'idle',
+    setWorldInfoUpdateStatus: mockSetWorldInfoUpdateStatus,
+  };
+});
+
+describe('WorldUpdateProgress', () => {
+  it('初期状態で「未実行」と表示される', () => {
+    render(<WorldUpdateProgress />);
+    expect(screen.getByText('未実行')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '更新' })).toBeEnabled();
+  });
+
+  it('更新対象が0件なら「更新対象なし」と表示される', async () => {
+    render(<WorldUpdateProgress />);
+    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+    await waitFor(() => {
+      expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
+      expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('noTarget');
+    });
+  });
+
+  it('更新中は「更新中: x / y」と表示される', () => {
+    state.worldInfoUpdateStatus = 'updating';
+    state.processedCount = 1;
+    state.updateTargetTotal = 3;
+    render(<WorldUpdateProgress />);
+    expect(screen.getByText('更新中: 1 / 3')).toBeInTheDocument();
+  });
+
+  it('エラー時は「更新中にエラーが発生しました」と表示される', () => {
+    state.worldInfoUpdateStatus = 'error';
+    render(<WorldUpdateProgress />);
+    expect(screen.getByText('更新中にエラーが発生しました')).toBeInTheDocument();
+  });
+
+  it('完了時は「更新完了: x / y」と表示される', () => {
+    state.worldInfoUpdateStatus = 'completed';
+    state.processedCount = 2;
+    state.updateTargetTotal = 2;
+    render(<WorldUpdateProgress />);
+    expect(screen.getByText('更新完了: 2 / 2')).toBeInTheDocument();
+  });
+
+  it('更新ボタン押下でAPIが呼ばれ、正常に完了する', async () => {
+    window.dbAPI.getWorldIdsToUpdate = jest.fn().mockResolvedValue(['id1', 'id2']);
+    window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockResolvedValue({});
+
+    render(<WorldUpdateProgress />);
+    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(true);
+      expect(mockSetProcessedCount).toHaveBeenCalledWith(0);
+      expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('updating');
+      expect(window.dbAPI.getWorldIdsToUpdate).toHaveBeenCalled();
+      expect(mockSetUpdateTargetTotal).toHaveBeenCalledWith(2);
+    });
+
+    await act(async () => {
+      await jest.runAllTimersAsync();
+    });
+
+    await waitFor(() => {
+      expect(window.dbAPI.addOrUpdateWorldInfo).toHaveBeenCalledWith('id1');
+      expect(window.dbAPI.addOrUpdateWorldInfo).toHaveBeenCalledWith('id2');
+      expect(mockSetProcessedCount).toHaveBeenCalledWith(1);
+      expect(mockSetProcessedCount).toHaveBeenCalledWith(2);
+      expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
+      expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('completed');
+    });
+  });
+
+  it('更新中にAPIエラーが発生した場合はエラー状態になる', async () => {
+    window.dbAPI.getWorldIdsToUpdate = jest.fn().mockResolvedValue(['id1', 'id2']);
+    window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockImplementationOnce(() => {
+      throw new Error('fail');
+    });
+
+    render(<WorldUpdateProgress />);
+    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
+      expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('error');
+    });
+  });
+
+  it('更新中はボタンがdisabledになる', () => {
+    state.worldInfoIsUpdating = true;
+    render(<WorldUpdateProgress />);
+    expect(screen.getByRole('button', { name: '更新' })).toBeDisabled();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "jsx": "react-jsx"
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "jest.setup.ts"
   ]
 }


### PR DESCRIPTION
# 概要
ワールド情報登録タブと設定タブのユニットテストを追加します

また、eslintの設定が正しくなかったため修正しています