### PR TITLE
[変更] 例外処理のテストを行う際に正常に出力されるエラーログがjestのログに出力されないよう変更

### DIFF
--- a/src/contexts/recommend-provider.test.tsx
+++ b/src/contexts/recommend-provider.test.tsx
@@ -90,6 +90,26 @@ describe('RecommendProvider', () => {
     });
   });
 
+  it('Provider外でuseRecommendStateを使うとエラー', () => {
+    const ProviderOutside: React.FC = () => {
+      useRecommendState();
+      return null;
+    };
+    expect(() => render(<ProviderOutside />)).toThrow('useRecommendState must be used within a RecommendProvider');
+  });
+});
+
+describe('RecommendProvider', () => {
+  let errorSpy: jest.SpyInstance<void, [message?: any, ...optionalParams: any[]]>;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore(); // エラーログの抑制を解除
+  });
+
   it('getRecommendWorldでエラー時はnullになりトーストが呼ばれる', async () => {
     (window.dbAPI.getRandomRecommendedWorld as jest.Mock).mockResolvedValueOnce(mockWorldInfo).mockRejectedValueOnce('APIエラー');
     render(
@@ -97,29 +117,13 @@ describe('RecommendProvider', () => {
         <ConsumerComponent />
       </RecommendProvider>,
     );
-    let errorSpy;
-    try {
-      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
-      fireEvent.click(screen.getByTestId('get-world-button'));
-      await waitFor(() => {
-        expect(screen.getByTestId('world')).toHaveTextContent('none');
-        expect(addToast).toHaveBeenCalledWith(
-          expect.stringContaining('ワールド情報の取得に失敗しました。エラー: APIエラー'),
-          expect.anything(),
-        );
-      });
-    } finally {
-      if (errorSpy) {
-        errorSpy.mockRestore(); // エラーログの抑制を解除
-      }
-    }
-  });
-
-  it('Provider外でuseRecommendStateを使うとエラー', () => {
-    const ProviderOutside: React.FC = () => {
-      useRecommendState();
-      return null;
-    };
-    expect(() => render(<ProviderOutside />)).toThrow('useRecommendState must be used within a RecommendProvider');
+    fireEvent.click(screen.getByTestId('get-world-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('world')).toHaveTextContent('none');
+      expect(addToast).toHaveBeenCalledWith(
+        expect.stringContaining('ワールド情報の取得に失敗しました。エラー: APIエラー'),
+        expect.anything(),
+      );
+    });
   });
 });

--- a/src/contexts/recommend-provider.test.tsx
+++ b/src/contexts/recommend-provider.test.tsx
@@ -97,16 +97,22 @@ describe('RecommendProvider', () => {
         <ConsumerComponent />
       </RecommendProvider>,
     );
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
-    fireEvent.click(screen.getByTestId('get-world-button'));
-    await waitFor(() => {
-      expect(screen.getByTestId('world')).toHaveTextContent('none');
-      expect(addToast).toHaveBeenCalledWith(
-        expect.stringContaining('ワールド情報の取得に失敗しました。エラー: APIエラー'),
-        expect.anything(),
-      );
-    });
-    errorSpy.mockRestore(); // エラーログの抑制を解除
+    let errorSpy;
+    try {
+      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
+      fireEvent.click(screen.getByTestId('get-world-button'));
+      await waitFor(() => {
+        expect(screen.getByTestId('world')).toHaveTextContent('none');
+        expect(addToast).toHaveBeenCalledWith(
+          expect.stringContaining('ワールド情報の取得に失敗しました。エラー: APIエラー'),
+          expect.anything(),
+        );
+      });
+    } finally {
+      if (errorSpy) {
+        errorSpy.mockRestore(); // エラーログの抑制を解除
+      }
+    }
   });
 
   it('Provider外でuseRecommendStateを使うとエラー', () => {

--- a/src/react-components/settings/world-update-progress.test.tsx
+++ b/src/react-components/settings/world-update-progress.test.tsx
@@ -120,20 +120,27 @@ describe('WorldUpdateProgress', () => {
   });
 
   it('更新中にAPIエラーが発生した場合はエラー状態になる', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
-    window.dbAPI.getWorldIdsToUpdate = jest.fn().mockResolvedValue(['id1', 'id2']);
-    window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockImplementationOnce(() => {
-      throw new Error('fail');
-    });
+    let errorSpy;
+    try {
+      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
 
-    render(<WorldUpdateProgress />);
-    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+      window.dbAPI.getWorldIdsToUpdate = jest.fn().mockResolvedValue(['id1', 'id2']);
+      window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockImplementationOnce(() => {
+        throw new Error('fail');
+      });
 
-    await waitFor(() => {
-      expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
-      expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('error');
-    });
-    errorSpy.mockRestore(); // エラーログの抑制を解除
+      render(<WorldUpdateProgress />);
+      fireEvent.click(screen.getByRole('button', { name: '更新' }));
+
+      await waitFor(() => {
+        expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
+        expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('error');
+      });
+    } finally {
+      if (errorSpy) {
+        errorSpy.mockRestore(); // エラーログの抑制を解除
+      }
+    }
   });
 
   it('更新中はボタンがdisabledになる', () => {

--- a/src/react-components/settings/world-update-progress.test.tsx
+++ b/src/react-components/settings/world-update-progress.test.tsx
@@ -120,6 +120,7 @@ describe('WorldUpdateProgress', () => {
   });
 
   it('更新中にAPIエラーが発生した場合はエラー状態になる', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
     window.dbAPI.getWorldIdsToUpdate = jest.fn().mockResolvedValue(['id1', 'id2']);
     window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockImplementationOnce(() => {
       throw new Error('fail');
@@ -132,6 +133,7 @@ describe('WorldUpdateProgress', () => {
       expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
       expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('error');
     });
+    errorSpy.mockRestore(); // エラーログの抑制を解除
   });
 
   it('更新中はボタンがdisabledになる', () => {

--- a/src/react-components/settings/world-update-progress.test.tsx
+++ b/src/react-components/settings/world-update-progress.test.tsx
@@ -119,33 +119,36 @@ describe('WorldUpdateProgress', () => {
     });
   });
 
-  it('更新中にAPIエラーが発生した場合はエラー状態になる', async () => {
-    let errorSpy;
-    try {
-      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
-
-      window.dbAPI.getWorldIdsToUpdate = jest.fn().mockResolvedValue(['id1', 'id2']);
-      window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockImplementationOnce(() => {
-        throw new Error('fail');
-      });
-
-      render(<WorldUpdateProgress />);
-      fireEvent.click(screen.getByRole('button', { name: '更新' }));
-
-      await waitFor(() => {
-        expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
-        expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('error');
-      });
-    } finally {
-      if (errorSpy) {
-        errorSpy.mockRestore(); // エラーログの抑制を解除
-      }
-    }
-  });
-
   it('更新中はボタンがdisabledになる', () => {
     state.worldInfoIsUpdating = true;
     render(<WorldUpdateProgress />);
     expect(screen.getByRole('button', { name: '更新' })).toBeDisabled();
+  });
+});
+
+describe('WorldUpdateProgress例外処理', () => {
+  let errorSpy: jest.SpyInstance<void, [message?: any, ...optionalParams: any[]]>;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {}); // エラーログを抑制
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore(); // エラーログの抑制を解除
+  });
+
+  it('更新中にAPIエラーが発生した場合はエラー状態になる', async () => {
+    window.dbAPI.getWorldIdsToUpdate = jest.fn().mockResolvedValue(['id1', 'id2']);
+    window.dbAPI.addOrUpdateWorldInfo = jest.fn().mockImplementationOnce(() => {
+      throw new Error('fail');
+    });
+
+    render(<WorldUpdateProgress />);
+    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => {
+      expect(mockSetWorldInfoIsUpdating).toHaveBeenCalledWith(false);
+      expect(mockSetWorldInfoUpdateStatus).toHaveBeenCalledWith('error');
+    });
   });
 });


### PR DESCRIPTION
# 概要
例外処理のテストを行う際に正常に出力されるエラーログがjestのログに出力されないよう変更します。

console.errorがjestのログに出力され、テストが成功したかどうかがわかりづらくなってしまっていた問題が解消されます。