### PR TITLE
[修正] SQLite3をWebpackバンドルに含めると初回起動時にエラーが発生するため除外する設定を行い修正

### DIFF
--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -19,4 +19,7 @@ export const mainConfig: Configuration = {
     alias,
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],
   },
+  externals: {
+    'better-sqlite3': 'commonjs2 better-sqlite3',
+  },
 };


### PR DESCRIPTION
# 概要
SQLite3をWebpackバンドルに含めると初回起動時にエラーが発生していたため設定を変更します。
