### PR TITLE
[更新] Electron37に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "classnames": "^2.5.1",
         "cross-env": "^7.0.3",
         "css-loader": "^6.11.0",
-        "electron": "36.2.0",
+        "electron": "^37.2.0",
         "eslint": "^9.26.0",
         "eslint-import-resolver-typescript": "^4.4.3",
         "eslint-plugin-import": "^2.31.0",
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "36.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-36.2.0.tgz",
-      "integrity": "sha512-5yldoRjBKxPQfI0QMX+qq750o3Nl8N1SZnJqOPMq0gZ6rIJ+7y4ZLp808GrFwjfTm05TYgq3GSD8FGuKQZqwEw==",
+      "version": "37.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.0.tgz",
+      "integrity": "sha512-dE6+qeg6SBUVd5d8CD2+GH82kh+gF1v40+hs+U+UOno681NMSGmBtgqwldQRpbvtnQDD7V2M9Cpfr3+Abw7aBg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "classnames": "^2.5.1",
     "cross-env": "^7.0.3",
     "css-loader": "^6.11.0",
-    "electron": "36.2.0",
+    "electron": "^37.2.0",
     "eslint": "^9.26.0",
     "eslint-import-resolver-typescript": "^4.4.3",
     "eslint-plugin-import": "^2.31.0",

--- a/src/react-components/common/world-card.scss
+++ b/src/react-components/common/world-card.scss
@@ -91,7 +91,7 @@
 
 :local(.world-property-value) {
   padding: 0px 4px;
-  width: 100%;
+  width: stretch;
 }
 
 :local(.invite-button) {
@@ -121,7 +121,7 @@
 
   textarea {
     resize: none;
-    width: 100%;
+    width: stretch;
     height: 4rem;
     padding: 8px;
     border: 2px solid theme.$gray;

--- a/src/react-components/data-entry/world-data-entry.scss
+++ b/src/react-components/data-entry/world-data-entry.scss
@@ -14,7 +14,7 @@
 
 :local(.search-input) {
   display: flex;
-  width: 100%;
+  width: stretch;
   gap: 8px;
 }
 

--- a/src/react-components/settings/general/world-update-progress.scss
+++ b/src/react-components/settings/general/world-update-progress.scss
@@ -14,7 +14,7 @@
 }
 
 :local(.progress-area) {
-  width: 100%;
+  width: stretch;
 }
 
 :local(.progress-label) {
@@ -24,7 +24,7 @@
 }
 
 :local(.progress-bar) {
-  width: 100%;
+  width: stretch;
   height: 16px;
   accent-color: theme.$light-blue;
 }

--- a/src/react-components/settings/settings.scss
+++ b/src/react-components/settings/settings.scss
@@ -12,5 +12,5 @@
 }
 
 :local(.settings-content) {
-  width: 100%;
+  width: stretch;
 }


### PR DESCRIPTION
# 概要
Electronのバージョンを37.2.0に更新します。
これに伴い、Chronium138ベースになったことで`width: stretch`が使用できるようになりました。
`width: 100%`より優れている場面があるためこちらに差し替えます。