### PR TITLE
[修正] exe化したプログラムが起動できなくなっていた問題を修正

### DIFF
--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -19,7 +19,9 @@ export const mainConfig: Configuration = {
     alias,
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],
   },
-  externals: {
-    'better-sqlite3': 'commonjs2 better-sqlite3',
-  },
+  ...(process.env.NODE_ENV === 'development' && {
+    externals: {
+      'better-sqlite3': 'commonjs2 better-sqlite3',
+    },
+  }),
 };


### PR DESCRIPTION
# 概要
exe化したプログラムが起動できなくなっていた問題を修正します。

- #69
の変更が原因で開発環境でエラーは出なくなりましたがexe化した際にプログラムが起動できなくなっていました。
環境を判別して除外を行うように修正します。