### PR TITLE
ワールド情報の表示が正しく管理されていなかった問題を修正

### DIFF
--- a/src/contexts/app-data-provider.tsx
+++ b/src/contexts/app-data-provider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 
 import { LLM_API_SERVICE_ID, llmApiService } from 'src/consts/const';
+import { VRChatWorldInfo } from 'src/types/renderer';
 import type { Genre, VisitStatus } from 'src/types/table';
 
 type AppData = {
@@ -10,6 +11,8 @@ type AppData = {
   setCurrentLLM?: React.Dispatch<React.SetStateAction<llmApiService>>;
   llmEnabled?: boolean;
   setLLMEnabled?: React.Dispatch<React.SetStateAction<boolean>>;
+  lastUpdatedWorldInfo?: VRChatWorldInfo | null;
+  setLastUpdatedWorldInfo?: React.Dispatch<React.SetStateAction<VRChatWorldInfo | null>>;
 };
 
 const AppDataContext = createContext<AppData>({});
@@ -20,6 +23,7 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [currentLLM, setCurrentLLM] = useState<llmApiService>(LLM_API_SERVICE_ID.openai);
   const [llmEnabled, setLLMEnabled] = useState(false);
+  const [lastUpdatedWorldInfo, setLastUpdatedWorldInfo] = useState<VRChatWorldInfo | null>(null);
 
   useEffect(() => {
     async function fetchAppData() {
@@ -64,7 +68,7 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AppDataContext.Provider value={{ genres, visitStatuses, currentLLM, setCurrentLLM, llmEnabled, setLLMEnabled }}>
+    <AppDataContext.Provider value={{ genres, visitStatuses, currentLLM, setCurrentLLM, llmEnabled, setLLMEnabled, lastUpdatedWorldInfo, setLastUpdatedWorldInfo }}>
       {children}
     </AppDataContext.Provider>
   );

--- a/src/contexts/bookmark-list-provider.tsx
+++ b/src/contexts/bookmark-list-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 import { useAppData } from './app-data-provider';
 
@@ -36,7 +36,7 @@ type BookmarkListContextValue = {
 const BookmarkListContext = createContext<BookmarkListContextValue>(undefined);
 
 export function BookmarkListProvider({ children }: { children: React.ReactNode }) {
-  const { visitStatuses } = useAppData();
+  const { visitStatuses, lastUpdatedWorldInfo } = useAppData();
 
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(DEFAULT_RESULT_PER_PAGE);
@@ -53,6 +53,16 @@ export function BookmarkListProvider({ children }: { children: React.ReactNode }
   const [filterVisible, setFilterVisible] = useState(true);
   const [viewType, setViewType] = useState<ViewType>(VIEW_TYPES.list);
   const [listViewSelectedWorld, setListViewSelectedWorld] = useState<VRChatWorldInfo | null>(null);
+
+  useEffect(() => {
+    if (
+      lastUpdatedWorldInfo &&
+      lastUpdatedWorldInfo.id === listViewSelectedWorld?.id &&
+      JSON.stringify(lastUpdatedWorldInfo) !== JSON.stringify(listViewSelectedWorld)
+    ) {
+      setListViewSelectedWorld(lastUpdatedWorldInfo);
+    }
+  }, [lastUpdatedWorldInfo]);
 
   return (
     <BookmarkListContext.Provider value={{

--- a/src/contexts/recommend-provider.tsx
+++ b/src/contexts/recommend-provider.tsx
@@ -7,6 +7,7 @@ import { VRChatWorldInfo } from 'src/types/renderer';
 
 type RecommendContextValue = {
   vrchatWorldInfo?: VRChatWorldInfo | null;
+  setVRChatWorldInfo?: React.Dispatch<React.SetStateAction<VRChatWorldInfo | null>>;
   getRecommendWorld?: () => Promise<void>;
   getLLMRecommendWorld?: () => Promise<void>;
   recommendType?: RecommendType;
@@ -82,7 +83,7 @@ export function RecommendProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <RecommendContext.Provider value={{ vrchatWorldInfo, getRecommendWorld, getLLMRecommendWorld, recommendType, setRecommendType, requestMessage, setRequestMessage, loading, reason }}>
+    <RecommendContext.Provider value={{ vrchatWorldInfo, setVRChatWorldInfo, getRecommendWorld, getLLMRecommendWorld, recommendType, setRecommendType, requestMessage, setRequestMessage, loading, reason }}>
       {children}
     </RecommendContext.Provider>
   );

--- a/src/contexts/recommend-provider.tsx
+++ b/src/contexts/recommend-provider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 
+import { useAppData } from './app-data-provider';
 import { useToast } from './toast-provider';
 
 import { NoticeType, RECOMMEND_TYPE, RecommendType } from 'src/consts/const';
@@ -26,6 +27,7 @@ export function RecommendProvider({ children }: { children: React.ReactNode }) {
   const [requestMessage, setRequestMessage] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
   const [reason, setReason] = useState<string | null>(null);
+  const { lastUpdatedWorldInfo } = useAppData();
   const { addToast } = useToast();
 
   async function getRecommendWorld() {
@@ -81,6 +83,16 @@ export function RecommendProvider({ children }: { children: React.ReactNode }) {
       }
     });
   }, []);
+
+  useEffect(() => {
+    if (
+      lastUpdatedWorldInfo &&
+      lastUpdatedWorldInfo.id === vrchatWorldInfo?.id &&
+      JSON.stringify(lastUpdatedWorldInfo) !== JSON.stringify(vrchatWorldInfo)
+    ) {
+      setVRChatWorldInfo(lastUpdatedWorldInfo);
+    }
+  }, [lastUpdatedWorldInfo]);
 
   return (
     <RecommendContext.Provider value={{ vrchatWorldInfo, setVRChatWorldInfo, getRecommendWorld, getLLMRecommendWorld, recommendType, setRecommendType, requestMessage, setRequestMessage, loading, reason }}>

--- a/src/contexts/world-data-entry-provider.tsx
+++ b/src/contexts/world-data-entry-provider.tsx
@@ -1,4 +1,6 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+import { useAppData } from './app-data-provider';
 
 import type { VRChatWorldInfo } from 'src/types/renderer';
 
@@ -14,6 +16,17 @@ const WorldDataEntryContext = createContext<WorldDataEntryContextValue>(undefine
 export function WorldDataEntryProvider({ children }: { children: React.ReactNode }) {
   const [worldIdOrUrl, setWorldIdOrUrl] = useState<string>('');
   const [vrchatWorldInfo, setVRChatWorldInfo] = useState<VRChatWorldInfo | null>(null);
+  const { lastUpdatedWorldInfo } = useAppData();
+
+  useEffect(() => {
+    if (
+      lastUpdatedWorldInfo &&
+      lastUpdatedWorldInfo.id === vrchatWorldInfo?.id &&
+      JSON.stringify(lastUpdatedWorldInfo) !== JSON.stringify(vrchatWorldInfo)
+    ) {
+      setVRChatWorldInfo(lastUpdatedWorldInfo);
+    }
+  }, [lastUpdatedWorldInfo]);
 
   return (
     <WorldDataEntryContext.Provider value={{

--- a/src/react-components/bookmark-list/bookmark-list-detail.tsx
+++ b/src/react-components/bookmark-list/bookmark-list-detail.tsx
@@ -5,13 +5,13 @@ import { WorldCard } from 'commonComponents/world-card';
 import { useBookmarkListState } from 'src/contexts/bookmark-list-provider';
 import { VRChatWorldInfo } from 'src/types/renderer';
 
-export function BookmarkListDetail({ worldInfo } : {worldInfo: VRChatWorldInfo}) {
+export function BookmarkListDetail({ worldInfo, updateBookmarkList } : {worldInfo: VRChatWorldInfo, updateBookmarkList: (worldInfo: VRChatWorldInfo) => void }) {
   const { setListViewSelectedWorld } = useBookmarkListState();
 
   return (
     <>
       <div className={styles.backButton} onClick={() => setListViewSelectedWorld(null)}><LeftArrowIcon /></div>
-      <WorldCard worldInfo={worldInfo} />
+      <WorldCard worldInfo={worldInfo} setVRChatWorldInfo={updateBookmarkList} />
     </>
   );
 }

--- a/src/react-components/bookmark-list/bookmark-list.tsx
+++ b/src/react-components/bookmark-list/bookmark-list.tsx
@@ -111,6 +111,15 @@ export function BookmarkList() {
     return pages;
   }
 
+  function updateBookmarkList(worldInfo: VRChatWorldInfo) {
+    setBookmarkList(bookmarkList.map((world) => {
+      if (world.id === worldInfo.id) {
+        return worldInfo;
+      }
+      return world;
+    }));
+  }
+
   return (
     <AnimatePresence mode='wait'>
       { listViewSelectedWorld ? (
@@ -121,7 +130,7 @@ export function BookmarkList() {
           exit={{ opacity: 0, x: 40 }}
           transition={{ duration: 0.3 }}
         >
-          <BookmarkListDetail worldInfo={listViewSelectedWorld}/>
+          <BookmarkListDetail worldInfo={listViewSelectedWorld} updateBookmarkList={updateBookmarkList}/>
         </motion.div>
       ) : (
         <motion.div
@@ -249,7 +258,7 @@ export function BookmarkList() {
           {viewType === VIEW_TYPES.grid && (
             <div className={styles.worldCardList}>
               {bookmarkList && bookmarkList.map((worldInfo) => (
-                <WorldCard key={worldInfo.id} worldInfo={worldInfo} />
+                <WorldCard key={worldInfo.id} worldInfo={worldInfo} setVRChatWorldInfo={updateBookmarkList}/>
               ))}
             </div>
           )}

--- a/src/react-components/common/world-card.spec.tsx
+++ b/src/react-components/common/world-card.spec.tsx
@@ -38,6 +38,7 @@ jest.mock('./world-tags', () => ({
   ),
 }));
 
+const mockSetVRChatWorldInfo = jest.fn();
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -45,7 +46,7 @@ beforeEach(() => {
 
 describe('WorldCard', () => {
   it('ワールド名・作者・説明などが表示される', () => {
-    render(<WorldCard worldInfo={mockWorldInfo} />);
+    render(<WorldCard worldInfo={mockWorldInfo} setVRChatWorldInfo={mockSetVRChatWorldInfo} />);
     expect(screen.getByText(mockWorldInfo.name)).toBeInTheDocument();
     expect(screen.getByText(`by ${mockWorldInfo.authorName}`)).toBeInTheDocument();
     expect(screen.getByText(mockWorldInfo.description)).toBeInTheDocument();
@@ -60,7 +61,7 @@ describe('WorldCard', () => {
   });
 
   it('ワールド名クリックでクリップボードにコピーされる', () => {
-    render(<WorldCard worldInfo={mockWorldInfo} />);
+    render(<WorldCard worldInfo={mockWorldInfo} setVRChatWorldInfo={mockSetVRChatWorldInfo} />);
     const clipboardButton = screen.getByLabelText('ワールド名をコピー');
     fireEvent.click(clipboardButton);
 
@@ -68,7 +69,7 @@ describe('WorldCard', () => {
   });
 
   it('メモを編集してフォーカスを外すとAPIが呼ばれる', async () => {
-    render(<WorldCard worldInfo={mockWorldInfo} />);
+    render(<WorldCard worldInfo={mockWorldInfo} setVRChatWorldInfo={mockSetVRChatWorldInfo} />);
     const textarea = screen.getByPlaceholderText('ワールドの補足情報を入力');
     fireEvent.change(textarea, { target: { value: '新しいメモ' } });
     fireEvent.blur(textarea);
@@ -76,33 +77,42 @@ describe('WorldCard', () => {
       expect(window.dbAPI.updateWorldBookmark).toHaveBeenCalledWith(
         expect.objectContaining({ note: '新しいメモ' }),
       );
+      expect(mockSetVRChatWorldInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ note: '新しいメモ' }),
+      );
     });
   });
 
   it('ジャンルチェックボックスをクリックするとAPIが呼ばれる', async () => {
-    render(<WorldCard worldInfo={mockWorldInfo} />);
+    render(<WorldCard worldInfo={mockWorldInfo} setVRChatWorldInfo={mockSetVRChatWorldInfo} />);
     const genreCheckbox = screen.getByLabelText('高品質');
     fireEvent.click(genreCheckbox);
     await waitFor(() => {
       expect(window.dbAPI.updateWorldGenres).toHaveBeenCalledWith(
         expect.objectContaining({ genreIds: [0, 1] }),
       );
+      expect(mockSetVRChatWorldInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ genreIds: [0, 1] }),
+      );
     });
   });
 
   it('訪問状況を変更するとAPIが呼ばれる', async () => {
-    render(<WorldCard worldInfo={mockWorldInfo} />);
+    render(<WorldCard worldInfo={mockWorldInfo} setVRChatWorldInfo={mockSetVRChatWorldInfo} />);
     const select = screen.getByRole('combobox');
     fireEvent.change(select, { target: { value: '1' } });
     await waitFor(() => {
       expect(window.dbAPI.updateWorldBookmark).toHaveBeenCalledWith(
         expect.objectContaining({ visitStatusId: 1 }),
       );
+      expect(mockSetVRChatWorldInfo).toHaveBeenCalledWith(
+        expect.objectContaining({ visitStatusId: 1 }),
+      );
     });
   });
 
   it('タグが表示される', () => {
-    render(<WorldCard worldInfo={mockWorldInfo} />);
+    render(<WorldCard worldInfo={mockWorldInfo} setVRChatWorldInfo={mockSetVRChatWorldInfo} />);
     expect(screen.getByText('["system_approved"]')).toBeInTheDocument();
   });
 });

--- a/src/react-components/common/world-card.spec.tsx
+++ b/src/react-components/common/world-card.spec.tsx
@@ -21,6 +21,7 @@ jest.mock('src/contexts/app-data-provider', () => ({
       { id: 2, name: 'Completed', name_jp: '完了' },
       { id: 3, name: 'Hidden', name_jp: '非表示' },
     ],
+    setLastUpdatedWorldInfo: jest.fn(),
   }),
 }));
 jest.mock('src/contexts/toast-provider', () => ({

--- a/src/react-components/common/world-card.tsx
+++ b/src/react-components/common/world-card.tsx
@@ -40,11 +40,16 @@ export function WorldCard({ worldInfo, setVRChatWorldInfo }: { worldInfo: VRChat
   const [visitStatusId, setVisitStatusId] = useState<number>(worldInfo.visitStatusId);
   const { addToast } = useToast();
   const [lastSaveNote, setLastSavedNote] = useState<string>(worldInfo.note);
-  const { genres, visitStatuses } = useAppData();
+  const { genres, visitStatuses, setLastUpdatedWorldInfo } = useAppData();
 
   function onClipboardClick() {
     writeClipboard(worldInfo.name);
     addToast('ワールド名をコピーしました', NoticeType.success);
+  }
+
+  function updateWorldInfo(newWorldInfo: VRChatWorldInfo) {
+    setVRChatWorldInfo(newWorldInfo);
+    setLastUpdatedWorldInfo(newWorldInfo);
   }
 
   async function handleUpdateWorldBookmark(options: UpdateWorldBookmarkOptions) {
@@ -52,13 +57,15 @@ export function WorldCard({ worldInfo, setVRChatWorldInfo }: { worldInfo: VRChat
       await window.dbAPI.updateWorldBookmark(options);
 
       if (options.note) {
-        setVRChatWorldInfo({ ...worldInfo, note: options.note });
+        const newWorldInfo = { ...worldInfo, note: options.note };
+        updateWorldInfo(newWorldInfo);
 
         addToast('メモを更新しました', NoticeType.success);
       }
 
       if(options.visitStatusId) {
-        setVRChatWorldInfo({ ...worldInfo, visitStatusId: options.visitStatusId });
+        const newWorldInfo = { ...worldInfo, visitStatusId: options.visitStatusId };
+        updateWorldInfo(newWorldInfo);
 
         addToast('訪問状況を更新しました', NoticeType.success);
       }
@@ -79,7 +86,8 @@ export function WorldCard({ worldInfo, setVRChatWorldInfo }: { worldInfo: VRChat
     try {
       await window.dbAPI.updateWorldGenres(options);
 
-      setVRChatWorldInfo({ ...worldInfo, genreIds: options.genreIds });
+      const newWorldInfo = { ...worldInfo, genreIds: options.genreIds };
+      updateWorldInfo(newWorldInfo);
 
       addToast('ジャンル設定を更新しました', NoticeType.success);
     } catch (error) {

--- a/src/react-components/common/world-card.tsx
+++ b/src/react-components/common/world-card.tsx
@@ -33,7 +33,7 @@ function ThumbnailArea({ thumbnailImageUrl, worldName, releaseStatus }: {thumbna
   );
 }
 
-export function WorldCard({ worldInfo }: { worldInfo: VRChatWorldInfo }) {
+export function WorldCard({ worldInfo, setVRChatWorldInfo }: { worldInfo: VRChatWorldInfo, setVRChatWorldInfo: React.Dispatch<React.SetStateAction<VRChatWorldInfo | null>> }) {
   const [selectedGenreIds, setSelectedGenreIds] = useState<number[]>(worldInfo.genreIds);
   const [debouncedSelectedGenreIds, setDebouncedSelectedGenreIds] = useState<number[]>(worldInfo.genreIds);
   const [worldNote, setWorldNote] = useState<string>(worldInfo.note);
@@ -52,10 +52,14 @@ export function WorldCard({ worldInfo }: { worldInfo: VRChatWorldInfo }) {
       await window.dbAPI.updateWorldBookmark(options);
 
       if (options.note) {
+        setVRChatWorldInfo({ ...worldInfo, note: options.note });
+
         addToast('メモを更新しました', NoticeType.success);
       }
 
       if(options.visitStatusId) {
+        setVRChatWorldInfo({ ...worldInfo, visitStatusId: options.visitStatusId });
+
         addToast('訪問状況を更新しました', NoticeType.success);
       }
     } catch (error) {
@@ -74,6 +78,9 @@ export function WorldCard({ worldInfo }: { worldInfo: VRChatWorldInfo }) {
   async function handleUpdateWorldGenres(options: UpdateWorldGenresOptions) {
     try {
       await window.dbAPI.updateWorldGenres(options);
+
+      setVRChatWorldInfo({ ...worldInfo, genreIds: options.genreIds });
+
       addToast('ジャンル設定を更新しました', NoticeType.success);
     } catch (error) {
       console.error('Failed to update world genres:', error);

--- a/src/react-components/data-entry/world-data-entry.tsx
+++ b/src/react-components/data-entry/world-data-entry.tsx
@@ -93,7 +93,7 @@ export function WorldDataEntry() {
         </div>
         <div className={classNames(styles.searchResult)}>
           {vrchatWorldInfo && (
-            <WorldCard worldInfo={vrchatWorldInfo} />
+            <WorldCard worldInfo={vrchatWorldInfo} setVRChatWorldInfo={setVRChatWorldInfo}/>
           )}
         </div>
       </motion.div>

--- a/src/react-components/recommend/recommend.tsx
+++ b/src/react-components/recommend/recommend.tsx
@@ -12,7 +12,7 @@ import { useAppData } from 'src/contexts/app-data-provider';
 import { useRecommendState } from 'src/contexts/recommend-provider';
 
 export function Recommend() {
-  const { vrchatWorldInfo, getRecommendWorld, getLLMRecommendWorld, recommendType, setRecommendType, requestMessage, setRequestMessage, loading, reason } = useRecommendState();
+  const { vrchatWorldInfo, setVRChatWorldInfo, getRecommendWorld, getLLMRecommendWorld, recommendType, setRecommendType, requestMessage, setRequestMessage, loading, reason } = useRecommendState();
   const { llmEnabled } = useAppData();
 
   const onGetWorldClick = async () => {
@@ -89,7 +89,7 @@ export function Recommend() {
         </div>
         <div>
           {vrchatWorldInfo && (
-            <WorldCard worldInfo={vrchatWorldInfo} />
+            <WorldCard worldInfo={vrchatWorldInfo} setVRChatWorldInfo={setVRChatWorldInfo} />
           )}
         </div>
       </motion.div>


### PR DESCRIPTION
# 概要
ワールド情報の表示が正しく管理されていなかった問題を修正します。

- ワールド情報を更新し、別画面に一度遷移したあと再度戻ると更新した情報が消えていた問題を修正
- 異なるタブで同一ワールドの情報を開いていた場合に、片方での更新がもう片方に反映されなかった問題を修正

# 関連issue
- #68 