### PR TITLE
[修正] currentLLMが保存されていない場合に上書きされないように修正

### DIFF
--- a/src/contexts/app-data-provider.tsx
+++ b/src/contexts/app-data-provider.tsx
@@ -35,7 +35,9 @@ export function AppDataProvider({ children }: { children: React.ReactNode }) {
       setVisitStatuses(visitStatuses);
 
       const service = await window.credentialStore.loadKey('currentLLM');
-      setCurrentLLM(service as LLMApiService);
+      if (service.length > 0) {
+        setCurrentLLM(service as LLMApiService); // 値が取得できた場合にのみセット
+      }
 
       let enabled = false;
       if (service === LLM_API_SERVICE_ID.openai) {


### PR DESCRIPTION
# 概要
currentLLMは未設定の場合も初期値でopenAIが選択される想定でしたが、useEffectにより上書きしてしまっていたため修正します。

# 関連issue
- #86 