### PR TITLE
[修正] トースト通知の表示時間が文字数に応じて伸びるように修正

### DIFF
--- a/src/utils/toast.scss
+++ b/src/utils/toast.scss
@@ -1,9 +1,5 @@
 @use 'assets/styles/theme.scss';
 
-$fadein: 0.4s;
-$visible: 2.5s;
-$fadeout: 0.6s;
-
 :local(.toast) {
   max-width: 80vw;
   width: fit-content;
@@ -15,7 +11,6 @@ $fadeout: 0.6s;
   pointer-events: none;
   text-align: center;
   word-break: break-word;
-  animation: fadein $fadein, fadeout $fadeout $visible + $fadein forwards;
 
   svg {
     width: 24px;

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -20,15 +20,15 @@ function Icon({ noticeType }: { noticeType: NoticeType }) {
 }
 
 const SECONDS_PER_CHARACTER = 0.08;
-const fadein = 0.4;
-const fadeout = 0.6;
+const FADEIN = 0.4;
+const FADEOUT = 0.6;
 
 export function Toast({ message, onClose, noticeType = NoticeType.info }: { message: string, onClose: () => void, noticeType?: NoticeType }) {
   if (!message) return null;
 
   const visible = Math.max(2, message.length * SECONDS_PER_CHARACTER);
 
-  const animation = `fadein ${fadein}s, fadeout ${fadeout}s ${fadein + visible}s forwards`;
+  const animation = `fadein ${FADEIN}s, fadeout ${FADEOUT}s ${FADEIN + visible}s forwards`;
 
   return (
     <div

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -19,16 +19,17 @@ function Icon({ noticeType }: { noticeType: NoticeType }) {
   return icons[noticeType];
 }
 
+const MIN_VISIBLE_DURATION_SEC = 2;
 const SECONDS_PER_CHARACTER = 0.08;
-const FADEIN = 0.4;
-const FADEOUT = 0.6;
+const FADEIN_SEC = 0.4;
+const FADEOUT_SEC = 0.6;
 
 export function Toast({ message, onClose, noticeType = NoticeType.info }: { message: string, onClose: () => void, noticeType?: NoticeType }) {
   if (!message) return null;
 
-  const visible = Math.max(2, message.length * SECONDS_PER_CHARACTER);
+  const visible = Math.max(MIN_VISIBLE_DURATION_SEC, message.length * SECONDS_PER_CHARACTER);
 
-  const animation = `fadein ${FADEIN}s, fadeout ${FADEOUT}s ${FADEIN + visible}s forwards`;
+  const animation = `fadein ${FADEIN_SEC}s, fadeout ${FADEOUT_SEC}s ${FADEIN_SEC + visible}s forwards`;
 
   return (
     <div

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -19,13 +19,14 @@ function Icon({ noticeType }: { noticeType: NoticeType }) {
   return icons[noticeType];
 }
 
+const SECONDS_PER_CHARACTER = 0.08;
 const fadein = 0.4;
 const fadeout = 0.6;
 
 export function Toast({ message, onClose, noticeType = NoticeType.info }: { message: string, onClose: () => void, noticeType?: NoticeType }) {
   if (!message) return null;
 
-  const visible = Math.max(2, message.length * 0.08);
+  const visible = Math.max(2, message.length * SECONDS_PER_CHARACTER);
 
   const animation = `fadein ${fadein}s, fadeout ${fadeout}s ${fadein + visible}s forwards`;
 

--- a/src/utils/toast.tsx
+++ b/src/utils/toast.tsx
@@ -19,15 +19,26 @@ function Icon({ noticeType }: { noticeType: NoticeType }) {
   return icons[noticeType];
 }
 
+const fadein = 0.4;
+const fadeout = 0.6;
+
 export function Toast({ message, onClose, noticeType = NoticeType.info }: { message: string, onClose: () => void, noticeType?: NoticeType }) {
   if (!message) return null;
 
+  const visible = Math.max(2, message.length * 0.08);
+
+  const animation = `fadein ${fadein}s, fadeout ${fadeout}s ${fadein + visible}s forwards`;
+
   return (
-    <div className={classNames(styles.toast, styles[noticeType])} onAnimationEnd={(e) => {
-      if (e.animationName.includes('fadeout')) {
-        onClose();
-      }
-    }}>
+    <div
+      className={classNames(styles.toast, styles[noticeType])}
+      style={{ animation }}
+      onAnimationEnd={(e) => {
+        if (e.animationName.includes('fadeout')) {
+          onClose();
+        }
+      }}
+    >
       <Icon noticeType={noticeType} />
       <span>{message}</span>
     </div>


### PR DESCRIPTION
# 概要
トースト通知の表示時間が文字数に応じて伸びるように修正します。
LLM実行時のエラー通知が出た場合など、文字数が多い場合にも変わらず一定の速度で通知が消えていた問題が解消されます。

# 関連issue
- #89 