### PR TITLE
[修正] ワールド情報登録時に正しいURLを入れても一瞬エラー表示が出る問題を修正

### DIFF
--- a/src/react-components/data-entry/world-data-entry.spec.tsx
+++ b/src/react-components/data-entry/world-data-entry.spec.tsx
@@ -83,7 +83,7 @@ describe('WorldDataEntry', () => {
     await waitFor(() => {
       expect(screen.getByText(/無効なワールドIDまたはURL/)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeDisabled();
-    }, { timeout: 600 });
+    });
   });
 
   it('有効なID入力時はボタンが有効', async () => {
@@ -97,7 +97,7 @@ describe('WorldDataEntry', () => {
     await waitFor(() => {
       expect(screen.queryByText(/無効なワールドIDまたはURL/)).not.toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeEnabled();
-    }, { timeout: 600 });
+    });
   });
 
   it('ボタン押下でAPIが呼ばれ、新規登録トーストとsetVRChatWorldInfoが呼ばれる', async () => {

--- a/src/react-components/data-entry/world-data-entry.spec.tsx
+++ b/src/react-components/data-entry/world-data-entry.spec.tsx
@@ -72,20 +72,32 @@ describe('WorldDataEntry', () => {
     expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeInTheDocument();
   });
 
-  it('無効なID入力時にエラーメッセージが表示される', () => {
+  it('無効なID入力時にエラーメッセージが表示される', async () => {
     const state = useWorldDataEntryState();
     state.worldIdOrUrl = 'invalid';
     render(<WorldDataEntry />);
-    expect(screen.getByText(/無効なワールドIDまたはURL/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeDisabled();
+    const inputText = screen.getByPlaceholderText('World ID or World URL');
+    fireEvent.change(inputText, { target: { value: 'invalid' } });
+    fireEvent.blur(inputText);
+
+    await waitFor(() => {
+      expect(screen.getByText(/無効なワールドIDまたはURL/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeDisabled();
+    }, { timeout: 600 });
   });
 
-  it('有効なID入力時はボタンが有効', () => {
+  it('有効なID入力時はボタンが有効', async () => {
     const state = useWorldDataEntryState();
     state.worldIdOrUrl = WORLD_ID;
     render(<WorldDataEntry />);
-    expect(screen.queryByText(/無効なワールドIDまたはURL/)).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeEnabled();
+    const inputText = screen.getByPlaceholderText('World ID or World URL');
+    fireEvent.change(inputText, { target: { value: WORLD_ID } });
+    fireEvent.blur(inputText);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/無効なワールドIDまたはURL/)).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'ワールド情報登録' })).toBeEnabled();
+    }, { timeout: 600 });
   });
 
   it('ボタン押下でAPIが呼ばれ、新規登録トーストとsetVRChatWorldInfoが呼ばれる', async () => {

--- a/src/react-components/data-entry/world-data-entry.tsx
+++ b/src/react-components/data-entry/world-data-entry.tsx
@@ -15,10 +15,15 @@ import { debounce, getWorldId } from 'src/utils/util';
 export function WorldDataEntry() {
   const { addToast } = useToast();
   const { worldIdOrUrl, setWorldIdOrUrl, vrchatWorldInfo, setVRChatWorldInfo }= useWorldDataEntryState();
-  const [isWorldIdOrUrl, setIsWorldIdOrUrl] = useState<boolean>(getWorldId(worldIdOrUrl) !== null);
+  const [isWorldIdOrUrl, setIsWorldIdOrUrl] = useState<boolean | null>(null);
 
   const debouncedSetIsWorldIdOrUrl = useCallback(
     debounce((value: string) => {
+      if (value.length === 0) {
+        setIsWorldIdOrUrl(null);
+        return;
+      }
+
       setIsWorldIdOrUrl(getWorldId(value) !== null);
     }, 500),
     [],
@@ -61,7 +66,7 @@ export function WorldDataEntry() {
   }
 
   const validInput = worldIdOrUrl.length > 0 && isWorldIdOrUrl;
-  const invalidInput = worldIdOrUrl.length > 0 && !isWorldIdOrUrl;
+  const invalidInput = worldIdOrUrl.length > 0 && isWorldIdOrUrl === false;
 
   return (
     <AnimatePresence mode='wait'>

--- a/src/react-components/data-entry/world-data-entry.tsx
+++ b/src/react-components/data-entry/world-data-entry.tsx
@@ -65,7 +65,7 @@ export function WorldDataEntry() {
     }
   }
 
-  const validInput = worldIdOrUrl.length > 0 && isWorldIdOrUrl;
+  const validInput = worldIdOrUrl.length > 0 && isWorldIdOrUrl === true;
   const invalidInput = worldIdOrUrl.length > 0 && isWorldIdOrUrl === false;
 
   return (


### PR DESCRIPTION
# 概要
ワールド情報登録時に正しいURLを入れても一瞬エラー表示が出る問題を修正します。

isWorldIdOrUrlの状態にnullを追加し、falseと厳密に区別することで対処します。

# 関連issue

- #95 