### PR TITLE
[変更] ワールド一覧の初期状態を見直し

### DIFF
--- a/src/consts/const.ts
+++ b/src/consts/const.ts
@@ -113,3 +113,10 @@ export const UPSERT_RESULT = {
   update: 'update',
 } as const;
 export type UpsertResult = typeof UPSERT_RESULT[keyof typeof UPSERT_RESULT];
+
+
+export const BOOKMARK_LIST_INIT_MODE_ID = {
+  default: 'default',
+  discovery: 'discovery',
+} as const;
+export type BookmarkListInitModeId = typeof BOOKMARK_LIST_INIT_MODE_ID[keyof typeof BOOKMARK_LIST_INIT_MODE_ID];

--- a/src/contexts/bookmark-list-provider.tsx
+++ b/src/contexts/bookmark-list-provider.tsx
@@ -2,8 +2,8 @@ import { createContext, useContext, useEffect, useState } from 'react';
 
 import { useAppData } from './app-data-provider';
 
-import { DEFAULT_RESULT_PER_PAGE, GENRE, GenreType, OrderableColumnKey, SortOrder, VIEW_TYPES, ViewType } from 'src/consts/const';
-import { VRChatWorldInfo } from 'src/types/renderer';
+import { DEFAULT_RESULT_PER_PAGE, GENRE, GenreType, LOGIC_MODES, OrderableColumnKey, SortOrder, VIEW_TYPES, ViewType } from 'src/consts/const';
+import { LogicMode, VRChatWorldInfo } from 'src/types/renderer';
 
 
 type BookmarkListContextValue = {
@@ -13,8 +13,8 @@ type BookmarkListContextValue = {
   setLimit?: React.Dispatch<React.SetStateAction<number>>;
   selectedGenres?: GenreType[];
   setSelectedGenres?: React.Dispatch<React.SetStateAction<GenreType[]>>;
-  genreFilterMode?: 'and' | 'or';
-  setGenreFilterMode?: React.Dispatch<React.SetStateAction<'and' | 'or'>>;
+  genreFilterMode?: LogicMode;
+  setGenreFilterMode?: React.Dispatch<React.SetStateAction<LogicMode>>;
   selectedUncategorized?: boolean;
   setSelectedUncategorized?: React.Dispatch<React.SetStateAction<boolean>>;
   selectedVisitStatuses?: number[];
@@ -42,13 +42,10 @@ export function BookmarkListProvider({ children }: { children: React.ReactNode }
 
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(DEFAULT_RESULT_PER_PAGE);
-  const [selectedUncategorized, setSelectedUncategorized] = useState(false);
-  const [selectedGenres, setSelectedGenres] = useState<GenreType[]>([GENRE.high_quality]);
-  const [genreFilterMode, setGenreFilterMode] = useState<'and' | 'or'>('and');
-  const [selectedVisitStatuses, setSelectedVisitStatuses] = useState<number[]>(visitStatuses
-    .filter(v => v.name === 'Unvisited' || v.name === 'InProgress')
-    .map(v => v.id),
-  );
+  const [selectedUncategorized, setSelectedUncategorized] = useState(true);
+  const [selectedGenres, setSelectedGenres] = useState<GenreType[]>([]);
+  const [genreFilterMode, setGenreFilterMode] = useState<LogicMode>(LOGIC_MODES.or);
+  const [selectedVisitStatuses, setSelectedVisitStatuses] = useState<number[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedTerm, setDebouncedTerm] = useState('');
   const [orderBy, setOrderBy] = useState<OrderableColumnKey>('bookmark.created_at');

--- a/src/contexts/bookmark-list-provider.tsx
+++ b/src/contexts/bookmark-list-provider.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 
 import { useAppData } from './app-data-provider';
 
-import { DEFAULT_RESULT_PER_PAGE, GENRE, GenreType, LOGIC_MODES, OrderableColumnKey, SortOrder, VIEW_TYPES, ViewType } from 'src/consts/const';
+import { BOOKMARK_LIST_INIT_MODE_ID, DEFAULT_RESULT_PER_PAGE, GENRE, GenreType, LOGIC_MODES, OrderableColumnKey, SortOrder, VIEW_TYPES, ViewType } from 'src/consts/const';
 import { LogicMode, VRChatWorldInfo } from 'src/types/renderer';
 
 
@@ -53,6 +53,23 @@ export function BookmarkListProvider({ children }: { children: React.ReactNode }
   const [filterVisible, setFilterVisible] = useState(true);
   const [viewType, setViewType] = useState<ViewType>(VIEW_TYPES.list);
   const [listViewSelectedWorld, setListViewSelectedWorld] = useState<VRChatWorldInfo | null>(null);
+
+  useEffect(() => {
+    async function loadSettings() {
+      const bookmarkListInitModeValue = await window.credentialStore.loadKey('bookmarkListInitMode');
+
+      if (bookmarkListInitModeValue === BOOKMARK_LIST_INIT_MODE_ID.discovery) {
+        setSelectedUncategorized(false);
+        setSelectedGenres([GENRE.high_quality]);
+        setSelectedVisitStatuses(visitStatuses
+          .filter(v => v.name === 'Unvisited' || v.name === 'InProgress')
+          .map(v => v.id),
+        );
+      }
+    }
+
+    loadSettings();
+  });
 
   useEffect(() => {
     if (

--- a/src/react-components/settings/general/bookmark-list-init-mode-setting.scss
+++ b/src/react-components/settings/general/bookmark-list-init-mode-setting.scss
@@ -1,0 +1,14 @@
+@use 'assets/styles/theme.scss';
+
+:local(.modeSetting) {
+  display: flex;
+  gap: 8px;
+}
+
+:local(.modeWrapper) {
+  border: theme.$base-border theme.$light-gray;
+  border-radius: 8px;
+  padding: 8px;
+  flex: 1;
+  cursor: pointer;
+}

--- a/src/react-components/settings/general/bookmark-list-init-mode-setting.tsx
+++ b/src/react-components/settings/general/bookmark-list-init-mode-setting.tsx
@@ -1,0 +1,40 @@
+import styles from './bookmark-list-init-mode-setting.scss';
+
+import { BOOKMARK_LIST_INIT_MODE_ID, BookmarkListInitModeId } from 'src/consts/const';
+import { useSettingsTabState } from 'src/contexts/settings-tab-provider';
+
+export function BookmarkListInitModeSetting() {
+  const { bookmarkListInitMode, onChangeBookmarkListInitMode } = useSettingsTabState();
+
+  return (
+    <>
+      <span>
+        アプリ起動時のワールド一覧画面の状態を設定します。<br />
+      </span>
+      <div className={styles.modeSetting} >
+        <label className={styles.modeWrapper}>
+          <input
+            type="radio"
+            name="bookmarkListInitMode"
+            value={BOOKMARK_LIST_INIT_MODE_ID.default}
+            checked={bookmarkListInitMode === BOOKMARK_LIST_INIT_MODE_ID.default}
+            onChange={(e) => {onChangeBookmarkListInitMode(e.target.value as BookmarkListInitModeId);}}
+          />
+          <strong>デフォルト</strong>
+          <p>すべての登録ワールド情報が登録日順で表示されます。</p>
+        </label>
+        <label  className={styles.modeWrapper}>
+          <input
+            type="radio"
+            name="bookmarkListInitMode"
+            value={BOOKMARK_LIST_INIT_MODE_ID.discovery}
+            checked={bookmarkListInitMode === BOOKMARK_LIST_INIT_MODE_ID.discovery}
+            onChange={(e) => {onChangeBookmarkListInitMode(e.target.value as BookmarkListInitModeId);}}
+          />
+          <strong>ディスカバリー</strong>
+          <p>高品質タグ付きの未訪問または訪問中ワールドが表示されます。<br />ワールド探索を目的としている場合におすすめです。</p>
+        </label>
+      </div>
+    </>
+  );
+};

--- a/src/react-components/settings/general/general-settings.scss
+++ b/src/react-components/settings/general/general-settings.scss
@@ -1,0 +1,5 @@
+:local(.settings) {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/src/react-components/settings/general/general-settings.spec.tsx
+++ b/src/react-components/settings/general/general-settings.spec.tsx
@@ -4,13 +4,31 @@ import '@testing-library/jest-dom';
 
 import { GeneralSettings } from './general-settings';
 
+import { SettingsTabProvider } from 'src/contexts/settings-tab-provider';
+
+beforeAll(() => {
+  global.window.credentialStore = {
+    loadKey: jest.fn().mockResolvedValue(''),
+    saveKey: jest.fn().mockResolvedValue(undefined),
+    isKeySaved: jest.fn().mockResolvedValue(false),
+  };
+});
+
 jest.mock('./world-update-progress', () => ({
   WorldUpdateProgress: () => <div data-testid="mock-world-update-progress">Mock WorldUpdateProgress</div>,
 }));
 
+const addToast = jest.fn();
+jest.mock('src/contexts/toast-provider', () => ({
+  ToastProvider: ({ children }: any) => <>{children}</>,
+  useToast: () => ({
+    addToast,
+  }),
+}));
+
 describe('GeneralSettings', () => {
   it('一般設定が正しくレンダリングされる', () => {
-    render(<GeneralSettings />);
+    render(<SettingsTabProvider><GeneralSettings /></SettingsTabProvider>);
 
     // タイトルが表示されることを確認
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('一般');

--- a/src/react-components/settings/general/general-settings.tsx
+++ b/src/react-components/settings/general/general-settings.tsx
@@ -1,3 +1,5 @@
+import { BookmarkListInitModeSetting } from './bookmark-list-init-mode-setting';
+import styles from './general-settings.scss';
 import { WorldUpdateProgress } from './world-update-progress';
 
 import { ReactComponent as ToolboxIcon } from 'assets/images/MdiToolboxOutline.svg';
@@ -8,11 +10,18 @@ export function GeneralSettings() {
   return (
     <>
       <SettingsHeader Icon={ToolboxIcon} title="一般" />
-      <SettingItem
-        title="ワールドデータ更新"
-      >
-        <WorldUpdateProgress />
-      </SettingItem>
+      <div className={styles.settings}>
+        <SettingItem
+          title="ワールド一覧画面 モード設定"
+        >
+          <BookmarkListInitModeSetting />
+        </SettingItem>
+        <SettingItem
+          title="ワールドデータ更新"
+        >
+          <WorldUpdateProgress />
+        </SettingItem>
+      </div>
     </>
   );
 }

--- a/src/react-components/settings/general/world-update-progress.tsx
+++ b/src/react-components/settings/general/world-update-progress.tsx
@@ -47,7 +47,7 @@ export function WorldUpdateProgress() {
 
 
   return (
-    <>
+    <div>
       <span>
         24時間以上前に取得したワールドデータを対象に最新情報へ更新します。VRChatサーバーへの負荷軽減のため1件ごとに1秒待機します。
       </span>
@@ -66,6 +66,6 @@ export function WorldUpdateProgress() {
         </div>
         <Button onClick={handleUpdate} disabled={worldInfoIsUpdating} className={styles.updateButton}>更新</Button>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/react-components/settings/settings.spec.tsx
+++ b/src/react-components/settings/settings.spec.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
 
+import '@testing-library/jest-dom';
 import { Settings } from './settings';
+
+import { SettingsTabProvider } from 'src/contexts/settings-tab-provider';
 
 beforeAll(() => {
   global.window.credentialStore = {
@@ -11,24 +13,21 @@ beforeAll(() => {
   };
 });
 
-jest.mock('src/contexts/settings-tab-provider', () => ({
-  useSettingsTabState: () => ({
-    activeCategory: 'general',
-    setActiveCategory: jest.fn(),
-    updateTargetTotal: 0,
-    setUpdateTargetTotal: jest.fn(),
-    processedCount: 0,
-    setProcessedCount: jest.fn(),
-    worldInfoIsUpdating: false,
-    setWorldInfoIsUpdating: jest.fn(),
-    worldInfoUpdateStatus: 'idle',
-    setWorldInfoUpdateStatus: jest.fn(),
+const addToast = jest.fn();
+jest.mock('src/contexts/toast-provider', () => ({
+  ToastProvider: ({ children }: any) => <>{children}</>,
+  useToast: () => ({
+    addToast,
   }),
 }));
 
 describe('Settings', () => {
   it('設定画面が正しくレンダリングされる', () => {
-    render(<Settings />);
+    render(
+      <SettingsTabProvider>
+        <Settings />
+      </SettingsTabProvider>,
+    );
 
     // タイトルが表示されることを確認
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('設定');


### PR DESCRIPTION
# 概要
ワールド一覧の初期状態を見直し、全件が登録順で表示されるのをデフォルトとします。
未探索のワールドを一覧表示することも行いたかったため、設定画面にモード切替も実装しました。

# 関連issue
- #91 