### PR TITLE
[修正] ワールド一覧画面でデータ取得が発生し続けていた問題を修正

### DIFF
--- a/src/contexts/bookmark-list-provider.tsx
+++ b/src/contexts/bookmark-list-provider.tsx
@@ -69,7 +69,7 @@ export function BookmarkListProvider({ children }: { children: React.ReactNode }
     }
 
     loadSettings();
-  });
+  }, []);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
# 概要
ワールド一覧画面でデータ取得が発生し続けていた問題を修正します。
useEffectの依存配列が省略されていたため初回のみ発火するように修正します。