### PR TITLE
[修正] ワールド一覧画面のバグを修正

### DIFF
--- a/src/contexts/bookmark-list-provider.tsx
+++ b/src/contexts/bookmark-list-provider.tsx
@@ -42,7 +42,7 @@ export function BookmarkListProvider({ children }: { children: React.ReactNode }
 
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(DEFAULT_RESULT_PER_PAGE);
-  const [selectedUncategorized, setSelectedUncategorized] = useState(true);
+  const [selectedUncategorized, setSelectedUncategorized] = useState(false);
   const [selectedGenres, setSelectedGenres] = useState<GenreType[]>([]);
   const [genreFilterMode, setGenreFilterMode] = useState<LogicMode>(LOGIC_MODES.or);
   const [selectedVisitStatuses, setSelectedVisitStatuses] = useState<number[]>([]);

--- a/src/main/bookmark-service.ts
+++ b/src/main/bookmark-service.ts
@@ -107,7 +107,9 @@ function buildBookmarkListWhereClauses(options: BookmarkListOptions, params: Rec
       genreSubQuery.push('NOT EXISTS (SELECT 1 FROM world_genres wg WHERE world.id = wg.world_id)');
     }
 
-    whereClauses.push(`(${genreSubQuery.join(' OR ')})`);
+    if (genreSubQuery.length > 0) {
+      whereClauses.push(`(${genreSubQuery.join(' OR ')})`);
+    }
   } else if (options.genreFilterMode === LOGIC_MODES.and) {
     if (hasGenre && hasUncategorized) {
       // AND検索でジャンルが選択されていて、かつ「未分類」も選択されている状態はありえないため、常にfalseになる条件を追加


### PR DESCRIPTION
# 概要
ワールド一覧画面のバグを修正します。

- 初期表示で未分類にチェックが入っていた
未分類はチェックが外れている状態が想定であったため修正します。

- ジャンルによる抽出がない場合にエラーが発生し画面が壊れていた問題を修正
SQL構築ロジックに問題があり、画面が壊れていたため修正します。