### PR TITLE
[修正] ワールド説明で単語が長すぎる場合にUIが崩れる問題を修正

### DIFF
--- a/src/react-components/common/world-card.scss
+++ b/src/react-components/common/world-card.scss
@@ -106,6 +106,7 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  overflow-wrap: anywhere;
 }
 
 :local(.world-property-name) {


### PR DESCRIPTION
# 概要

ワールド説明で単語が長すぎる場合にUIが崩れる問題を修正します。